### PR TITLE
feature/testmode

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -97,8 +97,8 @@ class Gateway extends OffsiteGateway
         $gateway = static::createOmnipayGateway($this->getGatewayClassName());
 
         $gateway->setApiKey(Craft::parseEnv($this->apiKey));
-        $gateway->setLocale(Craft::parseEnv($this->locale));
-        $gateway->setTestMode( (Craft::parseEnv('MULTISAFEPAY_TEST_MODE') === "true") || $this->testMode );
+        $gateway->setLocale(Craft::parseEnv($this->locale));        
+        $gateway->setTestMode( Craft::parseBooleanEnv('$MULTISAFEPAY_TEST_MODE') || $this->testMode );
 
         return $gateway;
 

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -98,9 +98,10 @@ class Gateway extends OffsiteGateway
 
         $gateway->setApiKey(Craft::parseEnv($this->apiKey));
         $gateway->setLocale(Craft::parseEnv($this->locale));
-        $gateway->setTestMode($this->testMode);
+        $gateway->setTestMode( (Craft::parseEnv('MULTISAFEPAY_TEST_MODE') === "true") || $this->testMode );
 
         return $gateway;
+
     }
 
     /**

--- a/src/templates/gatewaySettings.html
+++ b/src/templates/gatewaySettings.html
@@ -31,6 +31,6 @@
 {{ lightswitchField({
   label: "Test mode?"|t('commerce'),
   name: 'testMode',
-  on: gateway.testMode,
+  on: parseBooleanEnv('$MULTISAFEPAY_TEST_MODE') or gateway.testMode,
   errors: gateway.getErrors('testMode'),
 }) }}


### PR DESCRIPTION
### Description

At the moment when using the project config and allowAdminChanges is disabled we need to disable/enable testmode for the gateway locally and push the changes ( project config ). With this PR we should be able to use an environment variable for setting the gateways testmode to true on our staging environment and false on production.
